### PR TITLE
Disable assignment on export default

### DIFF
--- a/lib/animated/AnimatedBar.js
+++ b/lib/animated/AnimatedBar.js
@@ -4,4 +4,4 @@
 import Bar from '../shape/Bar';
 import {Animated} from 'react-native';
 
-export default AnimatedBar = Animated.createAnimatedComponent(Bar);
+export default Animated.createAnimatedComponent(Bar);

--- a/lib/animated/AnimatedCircle.js
+++ b/lib/animated/AnimatedCircle.js
@@ -4,4 +4,4 @@
 import Circle from '../shape/Circle';
 import {Animated} from 'react-native';
 
-export default AnimatedCircle = Animated.createAnimatedComponent(Circle);
+export default Animated.createAnimatedComponent(Circle);


### PR DESCRIPTION
On React Native, I have no issues. But when trying to use this library on a React App using `react-app-rewired`, I receive the following error:

![screen shot 2018-10-24 at 14 34 37](https://user-images.githubusercontent.com/3157426/47459916-8b7d9a00-d79a-11e8-9c44-db8fe989b311.png)

But that gets fixed by removing
```js
export default X = 'value'
```

and instead using 

```js
export default 'value'
```

It is a simple fix but it does help me to use this library with `react-native-web`