### PR TITLE
Feature: CirclesLoader number of dots

### DIFF
--- a/lib/loader/CirclesLoader.js
+++ b/lib/loader/CirclesLoader.js
@@ -10,25 +10,18 @@ export default class CirclesLoader extends React.PureComponent {
     color: PropTypes.string,
     dotRadius: PropTypes.number,
     size: PropTypes.number,
+    numberDots: PropTypes.number,
   };
 
   static defaultProps = {
     color,
     dotRadius: 8,
     size: 40,
+    numberDots: 8,
   };
 
   state = {
-    opacities: [
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-      new Animated.Value(1),
-    ],
+    opacities: Array.apply(null, Array(this.props.numberDots)).map(function(){return new Animated.Value(1)}),
   };
   eachDegree = 360 / this.state.opacities.length;
   timers = [];


### PR DESCRIPTION
Implements new feature in CirclesLoader:  number of dots

default value: 8

Example: <CirclesLoader size={150} color="#612066" dotRadius={15}  numberDots={5} />
